### PR TITLE
Implementation Replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Download
 
 ```groovy
 dependencies {
-  compile 'com.bunk3r:spanez:2.x.x'
+  implementation 'com.bunk3r:spanez:2.x.x'
 }
 ```
 


### PR DESCRIPTION
Replaced compile with implementation as it is deprecated in 2018.